### PR TITLE
adds optional chaining in `getChunkShapeOverride` to better handle cases when `X`, `Y` or `T` properties are undefined/null

### DIFF
--- a/components/utils/data.js
+++ b/components/utils/data.js
@@ -132,14 +132,14 @@ const getChunkShapeOverride = (chunkShape, shape, dimensions, axes) => {
 
   const fullSpace =
     dimensions
-      .filter((d) => [axes.X, axes.Y].includes(d))
+      .filter((d) => [axes?.X, axes?.Y].includes(d))
       .every((d) => d <= 360) &&
     chunkShape.reduce((product, d) => product * d, 1) < 1000000
 
   return dimensions.map((d, i) => {
-    if ([axes.X, axes.Y].includes(d)) {
+    if ([axes?.X, axes?.Y].includes(d)) {
       return fullSpace ? chunkShape[i] : Math.min(128, chunkShape[i])
-    } else if (d === axes.T) {
+    } else if (d === axes?.T) {
       return Math.min(30, shape[i])
     } else {
       return 1
@@ -170,6 +170,7 @@ const getChunksOverrides = (metadata, variables, cfAxes) => {
     const shape = metadata.metadata[`${variable}/.zarray`].shape
     const dimensions =
       metadata.metadata[`${variable}/.zattrs`]['_ARRAY_DIMENSIONS']
+
     const chunks = getChunkShapeOverride(
       nativeChunks,
       shape,
@@ -200,6 +201,7 @@ export const getArrays = async (
   { url, metadata, variables, cfAxes, pyramid }
 ) => {
   // TODO: instantiate store with headers and clean up manual overrides
+
   const headers = pyramid ? {} : getChunksHeader(metadata, variables, cfAxes)
   const chunksOverrides = pyramid
     ? {}


### PR DESCRIPTION
I ran into this issue when working with `https://ncsa.osn.xsede.org/Pangeo/pangeo-cmems-duacs`. nciew-js was struggling to retrieve chunk overrides for `lon_bnds   (longitude, nv)`, and `lat_bnds   (time, latitude, nv)` variables

```python
In [2]: ds = xr.open_zarr("https://ncsa.osn.xsede.org/Pangeo/pangeo-cmems-duacs")

In [3]: ds
Out[3]:
<xarray.Dataset> Size: 517GB
Dimensions:    (time: 8901, latitude: 720, longitude: 1440, nv: 2)
Coordinates:
    crs        int32 4B ...
    lat_bnds   (time, latitude, nv) float32 51MB dask.array<chunksize=(5, 720, 2), meta=np.ndarray>
  * latitude   (latitude) float32 3kB -89.88 -89.62 -89.38 ... 89.38 89.62 89.88
    lon_bnds   (longitude, nv) float32 12kB dask.array<chunksize=(1440, 2), meta=np.ndarray>
  * longitude  (longitude) float32 6kB 0.125 0.375 0.625 ... 359.4 359.6 359.9
  * nv         (nv) int32 8B 0 1
  * time       (time) datetime64[ns] 71kB 1993-01-01 1993-01-02 ... 2017-05-15
Data variables:
    adt        (time, latitude, longitude) float64 74GB dask.array<chunksize=(5, 720, 1440), meta=np.ndarray>
    err        (time, latitude, longitude) float64 74GB dask.array<chunksize=(5, 720, 1440), meta=np.ndarray>
    sla        (time, latitude, longitude) float64 74GB dask.array<chunksize=(5, 720, 1440), meta=np.ndarray>
    ugos       (time, latitude, longitude) float64 74GB dask.array<chunksize=(5, 720, 1440), meta=np.ndarray>
    ugosa      (time, latitude, longitude) float64 74GB dask.array<chunksize=(5, 720, 1440), meta=np.ndarray>
    vgos       (time, latitude, longitude) float64 74GB dask.array<chunksize=(5, 720, 1440), meta=np.ndarray>
    vgosa      (time, latitude, longitude) float64 74GB dask.array<chunksize=(5, 720, 1440), meta=np.ndarray>
Attributes: (12/43)
    Conventions:                     CF-1.6
    Metadata_Conventions:            Unidata Dataset Discovery v1.0
    cdm_data_type:                   Grid
    comment:                         Sea Surface Height measured by Altimetry...
    contact:                         servicedesk.cmems@mercator-ocean.eu
    creator_email:                   servicedesk.cmems@mercator-ocean.eu
    ...                              ...
    summary:                         SSALTO/DUACS Delayed-Time Level-4 sea su...
    time_coverage_duration:          P1D
    time_coverage_end:               1993-01-01T12:00:00Z
    time_coverage_resolution:        P1D
    time_coverage_start:             1992-12-31T12:00:00Z
    title:                           DT merged all satellites Global Ocean Gr...
```

Cc @katamartin. this address https://github.com/carbonplan/leap-data-catalog/issues/40#issue-2262199172