### PR TITLE
Also handle cartesian_axis values

### DIFF
--- a/components/utils/data.js
+++ b/components/utils/data.js
@@ -707,6 +707,8 @@ const inferCfAxes = (metadata, pyramid) => {
         if (dimAttrs) {
           if (dimAttrs.axis) {
             accum[dimAttrs.axis] = dim // collect axis information
+          } else if (dimAttrs.cartesian_axis) {
+            accum[dimAttrs.cartesian_axis] = dim
           }
           // ensure time is captured if it has a 'calendar' attribute
           if (dimAttrs.calendar && !accum.T) {


### PR DESCRIPTION
cc @norlandrhagen @andersy005 

Fixes `No CF axes information provided and unable to infer from metadata.` error for https://ncsa.osn.xsede.org/Pangeo/pangeo-forge/soda342/5day_ice.zarr/