### PR TITLE
Add basic spatial coordinate check

### DIFF
--- a/components/data/store.js
+++ b/components/data/store.js
@@ -91,21 +91,24 @@ const useStore = create((set, get) => ({
     })
     _registerLoading(name)
 
-    const { centerPoint: variableCenterPoint, selectors } =
-      await dataset.initializeVariable(name)
+    let cp
+    try {
+      const { centerPoint: variableCenterPoint, selectors } =
+        await dataset.initializeVariable(name)
+      set({ selectors })
+      cp = centerPoint ?? variableCenterPoint
+    } catch (e) {
+      set({ error: e.message })
+      _unregisterLoading(name)
+      return
+    }
 
-    set({ selectors })
-
-    await dataset.updateSelection(
-      centerPoint ?? variableCenterPoint,
-      zoom,
-      selectors
-    )
+    await dataset.updateSelection(cp, zoom, get().selectors)
     const clim = await dataset.getClim()
     set({ clim: urlClim ?? clim })
     _unregisterLoading(name)
 
-    get().resetMapProps(centerPoint ?? variableCenterPoint, zoom)
+    get().resetMapProps(cp, zoom)
   },
   resetMapProps: async (centerPoint, zoom) => {
     const { dataset, selectors } = get()

--- a/components/utils/data.js
+++ b/components/utils/data.js
@@ -230,7 +230,7 @@ export const getArrays = async (
 export const getVariableLevelInfo = async (
   name,
   { level, arrays, headers },
-  { cfAxes, metadata }
+  { cfAxes, metadata, pyramid }
 ) => {
   const dataArray = arrays[name]
   const prefix = level ? `${level}/` : ''
@@ -262,11 +262,40 @@ export const getVariableLevelInfo = async (
     }
   }, {})
 
+  const centerPoint = [
+    axes.X.array.data[Math.round((axes.X.array.data.length - 1) / 2)],
+    axes.Y.array.data[Math.round((axes.Y.array.data.length - 1) / 2)],
+  ]
+
+  if (!pyramid) {
+    const unhandledCoords = [
+      [
+        axes.X.array.data[0],
+        axes.X.array.data[axes.X.array.data.length - 1],
+      ].some((el) => Math.abs(el) > 360)
+        ? cfAxes[name].X
+        : null,
+      [
+        axes.Y.array.data[0],
+        axes.Y.array.data[axes.Y.array.data.length - 1],
+      ].some((el) => Math.abs(el) > 180)
+        ? cfAxes[name].Y
+        : null,
+    ].filter(Boolean)
+
+    if (unhandledCoords.length > 0) {
+      throw new Error(
+        `Cannot handle coordinate${
+          unhandledCoords.length > 1 ? 's' : ''
+        }: ${unhandledCoords.join(
+          ', '
+        )}. Spatial coordinates must refer to latitude and longitude.`
+      )
+    }
+  }
+
   return {
-    centerPoint: [
-      axes.X.array.data[Math.round((axes.X.array.data.length - 1) / 2)],
-      axes.Y.array.data[Math.round((axes.Y.array.data.length - 1) / 2)],
-    ],
+    centerPoint,
     northPole:
       gridMapping &&
       gridMapping.hasOwnProperty('grid_north_pole_longitude') &&


### PR DESCRIPTION
The `ncview-js` tool currently only supports (a) geospatial variables stored with lat/lon coordinates ([example](https://ncsa.osn.xsede.org/Pangeo/pangeo-forge/gpcp-feedstock/gpcp.zarr)) and (b) precomputed visualization "pyramids" ([example](https://storage.googleapis.com/carbonplan-maps/v2/demo/4d/tavg-prec-month)).

This PR adds a basic check of the spatial coordinate range values to throw an error in examples of obvious violations of (a).
![image](https://github.com/carbonplan/ncview-js/assets/12436887/7ebb8dc7-4285-42f1-b0d3-537948504d61)

See also https://github.com/carbonplan/ncview-js/issues/44