### PR TITLE
Add validation check that proxied datasets have equally spaced spatial coordinates

### DIFF
--- a/components/utils/data.js
+++ b/components/utils/data.js
@@ -8,7 +8,7 @@ import {
   // LZ4,
   // Zstd,
 } from 'numcodecs'
-
+import { deviation, extent } from 'd3-array'
 import { PROJECTIONS, ASPECTS } from '../constants'
 
 const COMPRESSORS = {
@@ -270,6 +270,19 @@ export const getVariableLevelInfo = async (
   const axes = ['X', 'Y'].reduce((accum, key, i) => {
     const index = dimensions.indexOf(cfAxes[name][key])
     const array = coordinates[i]
+    const stepValues = array.data.reduce((a, d, i) => {
+      if (i === 0) return a
+      const delta = d - array.data[i - 1]
+      a.add(delta)
+      return a
+    }, new Set())
+    const stepDeviation = deviation(stepValues)
+    if (stepDeviation && stepDeviation > 1e-10) {
+      throw new Error(
+        `Cannot handle coordinate: ${cfAxes[name][key]}. Spatial coordinates must be equally spaced.`
+      )
+    }
+
     const step = Math.abs(Number(array.data[0]) - Number(array.data[1]))
     const reversed = array.data[0] > array.data[array.data.length - 1]
 

--- a/components/utils/data.js
+++ b/components/utils/data.js
@@ -8,7 +8,7 @@ import {
   // LZ4,
   // Zstd,
 } from 'numcodecs'
-import { deviation, extent } from 'd3-array'
+import { deviation } from 'd3-array'
 import { PROJECTIONS, ASPECTS } from '../constants'
 
 const COMPRESSORS = {

--- a/components/utils/data.js
+++ b/components/utils/data.js
@@ -278,7 +278,7 @@ export const getVariableLevelInfo = async (
         return a
       }, new Set())
       const stepDeviation = deviation(stepValues)
-      if (stepDeviation && stepDeviation > 1e-10) {
+      if (stepDeviation && stepDeviation > 1e-3) {
         throw new Error(
           `Cannot handle coordinate: ${cfAxes[name][key]}. Spatial coordinates must be equally spaced.`
         )

--- a/components/utils/data.js
+++ b/components/utils/data.js
@@ -270,17 +270,19 @@ export const getVariableLevelInfo = async (
   const axes = ['X', 'Y'].reduce((accum, key, i) => {
     const index = dimensions.indexOf(cfAxes[name][key])
     const array = coordinates[i]
-    const stepValues = array.data.reduce((a, d, i) => {
-      if (i === 0) return a
-      const delta = d - array.data[i - 1]
-      a.add(delta)
-      return a
-    }, new Set())
-    const stepDeviation = deviation(stepValues)
-    if (stepDeviation && stepDeviation > 1e-10) {
-      throw new Error(
-        `Cannot handle coordinate: ${cfAxes[name][key]}. Spatial coordinates must be equally spaced.`
-      )
+    if (!pyramid) {
+      const stepValues = array.data.reduce((a, d, i) => {
+        if (i === 0) return a
+        const delta = d - array.data[i - 1]
+        a.add(delta)
+        return a
+      }, new Set())
+      const stepDeviation = deviation(stepValues)
+      if (stepDeviation && stepDeviation > 1e-10) {
+        throw new Error(
+          `Cannot handle coordinate: ${cfAxes[name][key]}. Spatial coordinates must be equally spaced.`
+        )
+      }
     }
 
     const step = Math.abs(Number(array.data[0]) - Number(array.data[1]))

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@mdx-js/react": "^2.1.5",
         "@next/mdx": "^12.3.1",
         "@theme-ui/color": "^0.15.3",
+        "d3-array": "^3.1.0",
         "d3-format": "^3.1.0",
         "d3-geo": "^3.1.0",
         "glsl-geo-projection": "^1.0.1",
@@ -670,6 +671,14 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/@carbonplan/maps/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dependencies": {
+        "internmap": "^1.0.0"
       }
     },
     "node_modules/@carbonplan/maps/node_modules/d3-color": {
@@ -5648,11 +5657,14 @@
       }
     },
     "node_modules/d3-array": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
-      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
       "dependencies": {
-        "internmap": "^1.0.0"
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-axis": {
@@ -5714,6 +5726,14 @@
         "d3-time-format": "2 - 3"
       }
     },
+    "node_modules/d3-scale/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
     "node_modules/d3-scale/node_modules/d3-format": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
@@ -5746,6 +5766,14 @@
       "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
       "dependencies": {
         "d3-time": "1 - 2"
+      }
+    },
+    "node_modules/d3-time/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dependencies": {
+        "internmap": "^1.0.0"
       }
     },
     "node_modules/d3-voronoi": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@mdx-js/react": "^2.1.5",
     "@next/mdx": "^12.3.1",
     "@theme-ui/color": "^0.15.3",
+    "d3-array": "^3.1.0",
     "d3-format": "^3.1.0",
     "d3-geo": "^3.1.0",
     "glsl-geo-projection": "^1.0.1",


### PR DESCRIPTION
This PR adds a validation check that throws an error when trying to render a variable whose spatial coordinates are not equally spaced (if the steps vary by `>  1e-3`).

Closes #48 